### PR TITLE
🐛 [Fix] 이 달의 기록 오늘 표시 문제

### DIFF
--- a/NewsHabit/Sources/AppDelegate.swift
+++ b/NewsHabit/Sources/AppDelegate.swift
@@ -11,11 +11,6 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // 이번 달 기록 설정
-        if UserDefaultsManager.lastMonth != Date().toMonthString() {
-            UserDefaultsManager.lastMonth = Date().toMonthString()
-            UserDefaultsManager.monthlyAllRead = []
-        }
         return true
     }
     

--- a/NewsHabit/Sources/Presenter/Main/MainView.swift
+++ b/NewsHabit/Sources/Presenter/Main/MainView.swift
@@ -207,6 +207,7 @@ extension MainView {
     
     @objc private func handleMonthlyRecordTap() {
         viewModel?.input.send(.setMainOption(.monthlyRecord))
+        monthlyRecordView.update()
     }
     
 }

--- a/NewsHabit/Sources/Presenter/Main/MonthlyRecord/MonthlyRecordView.swift
+++ b/NewsHabit/Sources/Presenter/Main/MonthlyRecord/MonthlyRecordView.swift
@@ -96,6 +96,12 @@ final class MonthlyRecordView: UIView, BaseViewProtocol {
     }
     
     func update() {
+        // 이번 달 기록 업데이트
+        if UserDefaultsManager.lastMonth != Date().toMonthString() {
+            UserDefaultsManager.lastMonth = Date().toMonthString()
+            UserDefaultsManager.monthlyAllRead = []
+        }
+        titleLabel.text = Date().toYearMonthString()
         numOfMonthlyAllReadLabel.text = "📚 \(UserDefaultsManager.monthlyAllRead.count)"
         collectionView.reloadData()
     }

--- a/NewsHabit/Sources/SceneDelegate.swift
+++ b/NewsHabit/Sources/SceneDelegate.swift
@@ -51,6 +51,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
+        // 이번 달 기록 설정
+        if UserDefaultsManager.lastMonth != Date().toMonthString() {
+            UserDefaultsManager.lastMonth = Date().toMonthString()
+            UserDefaultsManager.monthlyAllRead = []
+        }
+        // 알림 권한 체크
         NotificationCenterManager.shared.checkNotificationAuthorization { isAuthorized in
             UserDefaultsManager.isNotificationOn = isAuthorized
             if isAuthorized {


### PR DESCRIPTION
<!--
  :sparkles: [Feature] 제목
  :hammer: [Refactoring] 제목
  :bug: [Fix] 제목
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 앱 내에서 날짜가 바뀌었을 때 이 달의 기록이 업데이트 되는 로직이 없었습니다.
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - SceneDelegate에서 `sceneWillEnterForeground`일 때 이번 달 기록에서 사용되는 정보들을 업데이트하는 로직을 추가합니다.
  - MainView에서 메인 옵션(`오늘의 뉴스`, `이번 달 기록`)을 변경할 때 이번 달 기록에서 사용되는 정보들을 업데이트하는 로직을 추가합니다.
 ## 💡Issue 번호 <!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
  - close #155 