### PR TITLE
[Refactor] APIManager 리팩토링

### DIFF
--- a/NewsHabit/Sources/Utils/APIManager.swift
+++ b/NewsHabit/Sources/Utils/APIManager.swift
@@ -5,7 +5,6 @@
 //  Created by jiyeon on 3/6/24.
 //
 
-import Combine
 import Foundation
 
 import Alamofire
@@ -13,26 +12,21 @@ import Alamofire
 final class APIManager {
     
     static let shared = APIManager()
-    private var cancellables = Set<AnyCancellable>()
-    let serverIP = "https://newshabit.org"
-    
     private init() {}
+    
+    private let serverIP = "https://newshabit.org"
     
     func fetchData<T: Decodable>(_ uri: String, method: HTTPMethod = .get, parameters: [String: Any]? = nil, encoding: ParameterEncoding = URLEncoding.default, headers: HTTPHeaders? = nil, completion: @escaping (Result<T, AFError>) -> Void) {
         AF.request(serverIP + uri, method: method, parameters: parameters, encoding: encoding, headers: headers)
-            .validate()
-            .publishDecodable(type: T.self)
-            .value()
-            .sink(receiveCompletion: { result in
-                switch result {
-                case .finished: break
+            .validate() // Response 상태 코드가 200~299 범위 내에 있는지 확인
+            .responseDecodable(of: T.self) { response in
+                switch response.result {
+                case .success(let value):
+                    completion(.success(value))
                 case .failure(let error):
                     completion(.failure(error))
                 }
-            }, receiveValue: { response in
-                completion(.success(response))
-            })
-            .store(in: &cancellables)
+            }
     }
     
 }


### PR DESCRIPTION
## 📌 개요
  - APIManager 리팩토링

## 💻 작업 내용
  - `Combine`을 사용하지 않고, `completion` 핸들러를 사용하여 비동기 작업의 결과를 처리

## 🔗 이슈 번호 <!-- ex. "- close #4242" -->
  - close #173 
